### PR TITLE
🐛 4.1.1 fix `enrich` method call order dependency

### DIFF
--- a/packages/cheap-di/CHANGELOG.md
+++ b/packages/cheap-di/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 4.1.1
+
+🐛 fix `enrich` method call order dependency. Now you should be able to call in any order of dependency setup:
+```ts
+container
+  .registerImplementation(ApiImpl)
+  .as(Api)
+  .enrich(...);
+//
+container
+  .registerImplementation(ApiImpl)
+  .asSingleton(Api)
+  .enrich(...);
+//
+container
+  .registerImplementation(ApiImpl)
+  .enrich(...)
+  .as(Api);
+//
+container
+  .registerImplementation(ApiImpl)
+  .enrich(...)
+  .asSingleton(Api);
+```
+
+
 ## 4.1.0
 
 🚀 added `enrich` method to container to be able to wrap resolved instance with Proxy or something else that you need;

--- a/packages/cheap-di/package.json
+++ b/packages/cheap-di/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cheap-di",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "TypeScript dependency injection like Autofac in .Net",
   "type": "module",
   "scripts": {
@@ -30,11 +30,11 @@
     "dependency injection",
     "cheap di"
   ],
-  "_main": "./src/index.ts",
-  "_types": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "_main": "./dist/cjs/index.js",
+  "_module": "./dist/esm/index.js",
+  "_types": "./dist/types/index.d.ts",
   "build-instructions": {
     "name": "cheap-di",
     "files": [

--- a/packages/cheap-di/src/types.ts
+++ b/packages/cheap-di/src/types.ts
@@ -44,7 +44,7 @@ interface RegisteredImplementation<TClass> {
   as: AsBase<TClass, this>;
   /** as singleton (optionally super class) */
   asSingleton: AsSingleton<TClass, this>;
-  /** enrich instance when it will be resolved, example, if you want to wrap instance with Proxy */
+  /** enrich instance when it will be resolved, for example, if you want to wrap instance with Proxy */
   enrich: Enrich<TClass, this>;
   /** add parameters that will be passed to the class constructor */
   inject: Inject<this>;
@@ -53,7 +53,7 @@ interface RegisteredImplementation<TClass> {
 interface RegisteredInstance<TInstance> {
   /** or register the object as any class */
   as: AsBase<TInstance, this>;
-  /** enrich instance when it will be resolved, example, if you want to wrap instance with Proxy */
+  /** enrich instance when it will be resolved, for example, if you want to extend it but not right now, and only when it will be resolved */
   enrich: Enrich<TInstance, this>;
 }
 

--- a/tests/vite-project/src/tests/ContainerImpl.enrich.test.ts
+++ b/tests/vite-project/src/tests/ContainerImpl.enrich.test.ts
@@ -68,6 +68,41 @@ describe('enrich callbacks', () => {
     expect(usedMethods).toEqual(['getUsers', 'getRoles']);
   });
 
+  test('if instance is wrapped with Proxy when it is registered as something else ("enrich" called before "as")', () => {
+    abstract class Api {
+      abstract getUsers(): string[];
+      abstract getRoles(): string[];
+    }
+
+    class ApiImpl extends Api {
+      getUsers() {
+        return ['user-1', 'user-2'];
+      }
+      getRoles() {
+        return ['role-3', 'role-4'];
+      }
+    }
+
+    const usedMethods: string[] = [];
+
+    container
+      .registerImplementation(ApiImpl)
+      .enrich((api) => {
+        return new Proxy(api, {
+          get(instance, propertyName) {
+            usedMethods.push(propertyName.toString());
+            return instance[propertyName as keyof typeof instance];
+          },
+        });
+      })
+      .as(Api);
+    const api = container.resolve(Api)!;
+
+    expect(api.getUsers()).toEqual(['user-1', 'user-2']);
+    expect(api.getRoles()).toEqual(['role-3', 'role-4']);
+    expect(usedMethods).toEqual(['getUsers', 'getRoles']);
+  });
+
   test('if instance is wrapped with Proxy when it is registered as singleton of something else', () => {
     abstract class Api {
       abstract getUsers(): string[];
@@ -100,6 +135,107 @@ describe('enrich callbacks', () => {
 
     expect(api.getUsers()).toEqual(['user-1', 'user-2']);
     expect(api.getRoles()).toEqual(['role-3', 'role-4']);
+    expect(usedMethods).toEqual(['getUsers', 'getRoles']);
+  });
+
+  test('if instance is wrapped with Proxy when it is registered as singleton of something else ("enrich" called before "asSingleton")', () => {
+    abstract class Api {
+      abstract getUsers(): string[];
+      abstract getRoles(): string[];
+    }
+
+    class ApiImpl extends Api {
+      getUsers() {
+        return ['user-1', 'user-2'];
+      }
+      getRoles() {
+        return ['role-3', 'role-4'];
+      }
+    }
+
+    const usedMethods: string[] = [];
+
+    container
+      .registerImplementation(ApiImpl)
+      .enrich((api) => {
+        return new Proxy(api, {
+          get(instance, propertyName) {
+            usedMethods.push(propertyName.toString());
+            return instance[propertyName as keyof typeof instance];
+          },
+        });
+      })
+      .asSingleton(Api);
+    const api = container.resolve(Api)!;
+
+    expect(api.getUsers()).toEqual(['user-1', 'user-2']);
+    expect(api.getRoles()).toEqual(['role-3', 'role-4']);
+    expect(usedMethods).toEqual(['getUsers', 'getRoles']);
+  });
+
+  test('if instance is wrapped with Proxy when it is one of dependencies of target type', async () => {
+    class Api {
+      getUsers() {
+        return ['user-1', 'user-2'];
+      }
+      getRoles() {
+        return ['role-3', 'role-4'];
+      }
+    }
+
+    class Service {
+      constructor(public api: Api) {}
+    }
+
+    const usedMethods: string[] = [];
+
+    container.registerImplementation(Api).enrich((api) => {
+      return new Proxy(api, {
+        get(instance, propertyName, receiver) {
+          usedMethods.push(propertyName.toString());
+          return instance[propertyName as keyof typeof instance];
+        },
+      });
+    });
+    const service = container.resolve(Service)!;
+
+    expect(service.api.getUsers()).toEqual(['user-1', 'user-2']);
+    expect(service.api.getRoles()).toEqual(['role-3', 'role-4']);
+    expect(usedMethods).toEqual(['getUsers', 'getRoles']);
+  });
+
+  test('if instance is wrapped with Proxy when it is one of deep dependencies of target type', async () => {
+    class Api {
+      getUsers() {
+        return ['user-1', 'user-2'];
+      }
+      getRoles() {
+        return ['role-3', 'role-4'];
+      }
+    }
+
+    class Repository {
+      constructor(public api: Api) {}
+    }
+
+    class Service {
+      constructor(public repository: Repository) {}
+    }
+
+    const usedMethods: string[] = [];
+
+    container.registerImplementation(Api).enrich((api) => {
+      return new Proxy(api, {
+        get(instance, propertyName, receiver) {
+          usedMethods.push(propertyName.toString());
+          return instance[propertyName as keyof typeof instance];
+        },
+      });
+    });
+    const service = container.resolve(Service)!;
+
+    expect(service.repository.api.getUsers()).toEqual(['user-1', 'user-2']);
+    expect(service.repository.api.getRoles()).toEqual(['role-3', 'role-4']);
     expect(usedMethods).toEqual(['getUsers', 'getRoles']);
   });
 });


### PR DESCRIPTION
🐛 fix `enrich` method call order dependency. Now you should be able to call in any order of dependency setup:
```ts
container
  .registerImplementation(ApiImpl)
  .as(Api)
  .enrich(...);
//
container
  .registerImplementation(ApiImpl)
  .asSingleton(Api)
  .enrich(...);
//
container
  .registerImplementation(ApiImpl)
  .enrich(...)
  .as(Api);
//
container
  .registerImplementation(ApiImpl)
  .enrich(...)
  .asSingleton(Api);
```